### PR TITLE
Allow naming groups with spaces

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Videoconferencing server that is easy to deploy",
         "fr": "Serveur de visioconférence facile à déployer"
     },
-    "version": "0.2~ynh5",
+    "version": "0.2~ynh6",
     "url": "https://galene.org/",
     "license": "MIT",
     "maintainer": {
@@ -72,10 +72,6 @@
                 "ask": {
                     "en": "Choose a name for the group you want to create",
                     "fr": "Choisissez un nom pour le groupe que vous voulez créer"
-                },
-                "help": {
-                    "en": "The name will be used as filename (do not use space, dots or / in your name group).",
-                    "fr": "Le nom sera utilisé comme nom de fichier (n'utilisez pas d'espace, de points ou / dans votre groupe de noms)."
                 },
                 "default": "public",
                 "example": "public"

--- a/scripts/install
+++ b/scripts/install
@@ -55,7 +55,7 @@ ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
 ynh_app_setting_set --app=$app --key=admin --value=$admin
 ynh_app_setting_set --app=$app --key=is_public --value=$is_public
-ynh_app_setting_set --app=$app --key=group_name --value=$group_name
+ynh_app_setting_set --app=$app --key=group_name --value="$group_name"
 ynh_app_setting_set --app=$app --key=password --value=$password
 
 #=================================================
@@ -203,7 +203,7 @@ cp ../conf/passwd $final_path/data/passwd
 ynh_replace_string --match_string=__ADMIN__ --replace_string=$admin --target_file="$final_path/data/passwd"
 ynh_replace_string --match_string=__PASSWORD__ --replace_string=$password --target_file="$final_path/data/passwd"
 
-mv ../conf/groupname.json $final_path/groups/$group_name.json
+mv "../conf/groupname.json" "$final_path/groups/$group_name.json"
 ynh_replace_string --match_string=__ADMIN__ --replace_string=$admin --target_file="$final_path/groups/$group_name.json"
 ynh_replace_string --match_string=__PASSWORD__ --replace_string=$password --target_file="$final_path/groups/$group_name.json"
 


### PR DESCRIPTION
## Problem
#9 

## Solution
- *Add support to spaces in group names*

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
