### PR TITLE
Add new line in passwd file for user:password parsing

### DIFF
--- a/conf/passwd
+++ b/conf/passwd
@@ -1,1 +1,2 @@
 __ADMIN__:__PASSWORD__
+

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Videoconferencing server that is easy to deploy",
         "fr": "Serveur de visioconférence facile à déployer"
     },
-    "version": "0.3.5~ynh1",
+    "version": "0.3.5~ynh2",
     "url": "https://galene.org/",
     "license": "MIT",
     "maintainer": {
@@ -14,7 +14,7 @@
         "email": ""
     },
     "requirements": {
-        "yunohost": ">= 4.2.4"
+        "yunohost": ">= 4.1.7"
     },
     "multi_instance": false,
     "services": [


### PR DESCRIPTION
## Problem

- Statistics page cannot be loaded due to error while parsing `conf/passwd`. [This line](https://github.com/jech/galene/blob/de78f3ce62eecbffd3f456b0918a0b1cba08d2ae/webserver/webserver.go#L332) in upstream code expects to stop at a new line.

## Solution

- Add an extra line to `conf/passwd`
Closes #49 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
